### PR TITLE
Improve theme toggle component

### DIFF
--- a/dry-martini-web/src/components/ThemeToggle.js
+++ b/dry-martini-web/src/components/ThemeToggle.js
@@ -1,39 +1,29 @@
 // src/components/ThemeToggle.js
 import React from 'react';
-import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Switch from '@mui/material/Switch';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 
-const ToggleContainer = styled(Box)({
-  position: 'relative',
-  display: 'inline-flex',
-  alignItems: 'center',
-});
-
-const IconWrapper = styled(Box)({
-  position: 'absolute',
-  top: '50%',
-  transform: 'translateY(-50%)',
-  pointerEvents: 'none',
-});
+// Show only the active theme icon next to the switch without overlaying
+// to keep the UI clean.
 
 export default function ThemeToggle({ themeMode, toggleTheme }) {
+  const isDark = themeMode === 'dark';
+
   return (
-    <ToggleContainer sx={{ width: 48 }}>
-      <IconWrapper sx={{ left: 4 }}>
-        <Brightness7Icon fontSize="small" />
-      </IconWrapper>
+    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+      {isDark ? (
+        <Brightness4Icon fontSize="small" sx={{ mr: 0.5 }} />
+      ) : (
+        <Brightness7Icon fontSize="small" sx={{ mr: 0.5 }} />
+      )}
       <Switch
-        checked={themeMode === 'dark'}
+        checked={isDark}
         onChange={toggleTheme}
         color="default"
         size="small"
       />
-      <IconWrapper sx={{ right: 4 }}>
-        <Brightness4Icon fontSize="small" />
-      </IconWrapper>
-    </ToggleContainer>
+    </Box>
   );
 }


### PR DESCRIPTION
## Summary
- revert accidental backend formatting
- clean up theme toggle icon display

## Testing
- `black .` *(reformatted multiple files; reverted)*
- `flake8` *(fails: command not found)*
- `pytest`
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414a2adad8832285077ccb4ed9e106