### PR TITLE
Add spacing in topbar

### DIFF
--- a/dry-martini-web/src/components/TopBar.js
+++ b/dry-martini-web/src/components/TopBar.js
@@ -26,7 +26,7 @@ export default function TopBar({ themeMode, toggleTheme }) {
         </Link>
 
         <Tooltip title="Toggle light/dark theme">
-          <Box sx={{ ml: 1 }}>
+          <Box sx={{ ml: 2 }}>
             <ThemeToggle themeMode={themeMode} toggleTheme={toggleTheme} />
           </Box>
         </Tooltip>


### PR DESCRIPTION
## Summary
- widen margin between About link and Theme toggle

## Testing
- `black . --check` *(fails: would reformat many files)*
- `flake8` *(fails: command not found)*
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414f4fe3c88322b676ee9b1bf5ee5c