### PR TITLE
Use nginx in web Dockerfile

### DIFF
--- a/martini-web/Dockerfile.web
+++ b/martini-web/Dockerfile.web
@@ -18,19 +18,17 @@ COPY public ./public
 COPY src    ./src
 RUN npm run build
 
-# 2. Runtime stage: serve with 'serve' on port 3000
-FROM node:22-alpine
+# 2. Runtime stage: Nginx serving on port 80
+FROM nginx:stable-alpine
 
-WORKDIR /app
-
-# Install a lightweight static server
-RUN npm install --global serve
+# Copy custom nginx configuration to enable CORS
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Copy built assets from builder
-COPY --from=builder /app/build ./build
+COPY --from=builder /app/build /usr/share/nginx/html
 
-# Expose port 3000
-EXPOSE 3000
+# Expose port 80
+EXPOSE 80
 
-# Serve the build folder statically on 3000
-CMD ["serve", "-s", "build", "-l", "3000"]
+# Run nginx in the foreground
+CMD ["nginx", "-g", "daemon off;"]

--- a/martini-web/nginx.conf
+++ b/martini-web/nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    root /usr/share/nginx/html;
+
+    location / {
+        try_files $uri /index.html;
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE' always;
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+        if ($request_method = OPTIONS ) {
+            return 204;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- switch frontend container runtime to nginx
- expose port 80 instead of 3000
- add nginx CORS configuration allowing any origin

## Testing
- `pytest -q`
- `CI=true npm test` *(fails: Unable to find an element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_684969a1c6d48322839f68217522a5b6