### PR TITLE
Rename project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Dry Martini
+# Martini
 
-Dry Martini is a full-stack “Bond Explorer” application that provides investors and analysts with easy access to bond market data, document archives, and fund holding information. It consists of:
+Martini is a full-stack “Bond Explorer” application that provides investors and analysts with easy access to bond market data, document archives, and fund holding information. It consists of:
 
 - **Backend** (`martini/`): A Python FastAPI service that exposes REST endpoints, handles database interactions, and proxies PDF documents from Google Cloud Storage.  
 - **Frontend** (`martini-web/`): A React application (with Material-UI) that offers an interactive UI for browsing securities, viewing price charts, reading documents, and inspecting fund holdings.


### PR DESCRIPTION
## Summary
- rename project from Dry Martini to just Martini in docs

## Testing
- `pytest -q`
- `npm test -- --watchAll=false` *(fails: unable to find text "learn react")*

------
https://chatgpt.com/codex/tasks/task_e_68496fd3688c8322b1108bac22874d26